### PR TITLE
callerのJOIN時にcallerの識別子をcaller側にも返すようにした

### DIFF
--- a/lib/namespaces/caller_namespace.js
+++ b/lib/namespaces/caller_namespace.js
@@ -57,7 +57,11 @@ class CallerNamespace extends Namespace {
       yield actorService.save(actor)
       actorSocket.emit(JOIN, callerInfo(caller, messages))
 
-      return [ { key: actor.key, specs: actor.$specs } ]
+      return [ {
+        key: actor.key,
+        specs: actor.$specs,
+        as: caller.key
+      } ]
     }))
 
     // Handle leave request from caller
@@ -76,7 +80,10 @@ class CallerNamespace extends Namespace {
       yield actorService.save(actor)
       actorSocket.emit(LEAVE, callerInfo(caller, messages))
 
-      return [ { key: actor.key } ]
+      return [ {
+        key: actor.key,
+        as: caller.key
+      } ]
     }))
 
     // Handle fire request from caller


### PR DESCRIPTION
callerを識別するkeyはactorと違って接続時にhub側で生成される。それをcaller側にも伝えるようにした。