### PR TITLE
Actorのメソッドを呼び出すときにcallerの情報を渡すようにした

### DIFF
--- a/lib/connectors/caller_connector.js
+++ b/lib/connectors/caller_connector.js
@@ -95,7 +95,7 @@ class CallerConnector extends Connector {
       let caller = yield callerService.findBySocketId(id)
       yield invocationService.beginInvocation(pid, caller)
       process.nextTick(() =>
-        actorIO.to(actor.socketId).emit(PERFORM, Object.assign({}, data, { pid }))
+        actorIO.to(actor.socketId).emit(PERFORM, Object.assign({}, data, { pid }, callerInfo(caller)))
       )
 
       return [ {


### PR DESCRIPTION
actor対callerは1対多であり、メソッド呼び出し時にどのcallerから呼び出されたか判定する術が今の所なかったので。